### PR TITLE
Fixed syntax error in "commonly used awsconfig.xml"

### DIFF
--- a/doc_source/setup-unity.rst
+++ b/doc_source/setup-unity.rst
@@ -104,14 +104,13 @@ LogMetricsFormat property, valid values are JSON or standard.
 The following example shows the most commonly used settings in the awsconfig.xml file. For more
 information about specific service settings, see the service section below::
 
-    <?xml version="1.0" encoding="utf-8"?>
-    <aws region="us-west-2"
-        <logging logTo="UnityLogger"
-                 logResponses="Always"
-                 logMetrics="true"
-                 logMetricsFormat="JSON" />
-    />
-
+   <?xml version="1.0" encoding="utf-8"?>
+   <aws correctForClockSkew="true" region="us-west-2" >
+   <logging logTo="UnityLogger"
+            logResponses="Always"
+            logMetrics="true"
+            logMetricsFormat="JSON" />
+   </aws>
 
 Working with the link.xml file
 ------------------------------


### PR DESCRIPTION
Also correctForClockSkew="true" is required.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
